### PR TITLE
feat: add role-based permission checks

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -15,13 +15,18 @@ bot = commands.Bot(command_prefix='!', intents=intents)
 db = DetranDatabase()
 
 def verificar_permissao(interaction: discord.Interaction, comando: str) -> bool:
-    """Verifica se o usuário tem permissão para executar o comando"""
-    membro = db.get_membro_detran(str(interaction.user.id))
-    if not membro:
-        return False
-    
-    cargo = membro['cargo']
-    return comando in CARGOS_PERMISSOES.get(cargo, [])
+    """Verifica se o usuário possui cargos necessários para o comando."""
+    role_ids = [role.id for role in interaction.user.roles]
+
+    # Gerência tem acesso total
+    if ROLE_GERENCIA in role_ids:
+        return True
+
+    # Funcionários possuem acesso limitado
+    if ROLE_FUNCIONARIOS in role_ids:
+        return comando in PERMISSOES_FUNCIONARIOS
+
+    return False
 
 def criar_embed_erro(titulo: str, descricao: str) -> discord.Embed:
     """Cria um embed de erro"""

--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -4,6 +4,10 @@
 import os
 DISCORD_TOKEN = os.environ.get("TOKEN", "SEU_TOKEN_AQUI")
 
+# IDs de cargos do Discord
+ROLE_FUNCIONARIOS = 1404275629427261490
+ROLE_GERENCIA = 1405260058224234637
+
 # Configurações de permissões por cargo
 CARGOS_PERMISSOES = {
     "Diretor": [
@@ -21,6 +25,14 @@ CARGOS_PERMISSOES = {
         "veiculo_apreender", "veiculo_liberar", "multar", "blitz_iniciar", "blitz_finalizar"
     ]
 }
+
+# Comandos permitidos para o cargo padrão de funcionários
+PERMISSOES_FUNCIONARIOS = list({
+    comando
+    for cargo, comandos in CARGOS_PERMISSOES.items()
+    if cargo != "Diretor"
+    for comando in comandos
+})
 
 # Tabela de infrações e multas (baseada no documento oficial)
 TABELA_INFRACOES = {


### PR DESCRIPTION
## Summary
- add Discord role constants and default permission list
- verify commands based on user roles

## Testing
- `python -m py_compile detran_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7638ee4e48323a0ffcbfc9626818e

## Resumo por Sourcery

Implementa verificações de permissão baseadas em função adicionando constantes de ID de função do Discord e calculando uma lista padrão de permissões para funcionários, em seguida, atualiza a função de verificação de permissão para conceder acesso total às funções de gerência e limitar as funções de funcionários de acordo.

Novas Funcionalidades:
- Introduz constantes de função do Discord (ROLE_FUNCIONARIOS, ROLE_GERENCIA) e uma lista padrão de permissões para funcionários
- Concede acesso total a comandos para funções de gerência e restringe as funções de funcionários a um subconjunto calculado de comandos

Melhorias:
- Refatora `verificar_permissao` para usar IDs de função do Discord para verificações de permissão em vez de funções armazenadas no banco de dados

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement role-based permission checks by adding Discord role ID constants and computing a default staff permissions list, then update the permission verification function to grant full access to management roles and limit staff roles accordingly.

New Features:
- Introduce Discord role constants (ROLE_FUNCIONARIOS, ROLE_GERENCIA) and a default staff permissions list
- Grant full command access to management roles and restrict staff roles to a computed subset of commands

Enhancements:
- Refactor verificar_permissao to use Discord role IDs for permission checks instead of database-stored roles

</details>