### PR TITLE
Add staff control panel and member registration

### DIFF
--- a/detran_bot/MANUAL_OPERACAO.md
+++ b/detran_bot/MANUAL_OPERACAO.md
@@ -50,7 +50,7 @@ Filtra por cargo (opcional)
 
 ### Registrar Novo Jogador
 ```
-/registrar UTC58846 "João Silva" "(11) 99999-9999"
+/registrar_jogador UTC58846 "João Silva" "(11) 99999-9999"
 ```
 - **RG**: Identificador único do jogador no jogo
 - **Nome**: Nome do personagem no RP
@@ -258,7 +258,7 @@ Status: pendente, paga, recorrida
 
 ### "Jogador Não Encontrado"
 - Verifique se o RG está correto
-- Use `/registrar` se o jogador não estiver no sistema
+- Use `/registrar_jogador` se o jogador não estiver no sistema
 
 ### "Veículo Não Encontrado"
 - Confirme a placa digitada

--- a/detran_bot/README.md
+++ b/detran_bot/README.md
@@ -111,7 +111,8 @@ O bot usa os seguintes intents:
 ## 📋 Comandos Disponíveis
 
 ### Registro e CNH
-- `/registrar` - Registra um novo jogador
+- `/registrar` - Registro de novo membro
+- `/registrar_jogador` - Registra um novo jogador
 - `/cnh_emitir` - Emite uma nova CNH
 - `/cnh_consultar` - Consulta status da CNH
 - `/cnh_suspender` - Suspende CNH

--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -7,6 +7,16 @@ DISCORD_TOKEN = os.environ.get("TOKEN", "SEU_TOKEN_AQUI")
 # IDs de cargos do Discord
 ROLE_FUNCIONARIOS = 1404275629427261490
 ROLE_GERENCIA = 1405260058224234637
+# Cargo atribuído automaticamente a novos membros
+ROLE_INICIAL = 1403835890803146865
+# Cargo concedido após registro no servidor
+ROLE_REGISTRADO = 1408159947015065630
+
+# IDs de canais do Discord
+# Canal onde o painel de controle será publicado
+CANAL_PAINEL_FUNCIONARIOS = 1408158616783163616
+# Canal onde novos membros devem se registrar
+CANAL_REGISTRO = 1403794454413967526
 
 # Configurações de permissões por cargo
 CARGOS_PERMISSOES = {


### PR DESCRIPTION
## Summary
- add channel and role constants for onboarding and panel
- send control panel with quick command links and assign default role on join
- add self-registration command and update documentation

## Testing
- `python -m py_compile detran_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a76991c35c832383a136c51aded024

## Resumo por Sourcery

Adiciona painel de controle para a equipe e fluxo de integração de membros com atribuição de funções e auto-registro

Novas Funcionalidades:
- Introduz uma visualização do painel de controle da equipe com botões para acesso rápido a comandos em um canal dedicado
- Atribui automaticamente uma função inicial a novos membros ao entrarem
- Adiciona um comando slash de auto-registro para novos membros no canal de registro

Melhorias:
- Renomeia o comando de registro para /registrar_jogador e atualiza a documentação relacionada
- Adiciona constantes de configuração para as funções inicial e de registro e seus canais
- Habilita as intents de membro para suportar eventos de atribuição de função

Documentação:
- Atualiza o README e o manual de operação com os comandos de registro novos e renomeados

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add staff control panel and member onboarding flow with role assignments and self-registration

New Features:
- Introduce a staff control panel view with buttons for quick command access in a dedicated channel
- Automatically assign an initial role to new members on join
- Add a self-registration slash command for new members in the registration channel

Enhancements:
- Rename the registration command to /registrar_jogador and update related documentation
- Add configuration constants for initial and registered roles and their channels
- Enable member intents to support role assignment events

Documentation:
- Update README and operation manual with the new and renamed registration commands

</details>