### PR TITLE
feat: adiciona comando /painel

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -103,6 +103,21 @@ async def on_member_join(member: discord.Member):
     if role:
         await member.add_roles(role)
 
+# Comando para exibir o painel de controle
+@bot.tree.command(name="painel", description="Exibe o painel de controle do Detran")
+async def painel(interaction: discord.Interaction):
+    if not verificar_permissao(interaction, "painel"):
+        embed = criar_embed_erro("Sem Permissão", "Você não tem permissão para executar este comando.")
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        return
+
+    embed = discord.Embed(
+        title="Painel de Controle",
+        description="Utilize os botões abaixo para acessar funções rápidas.",
+        color=CORES["info"]
+    )
+    await interaction.response.send_message(embed=embed, view=PainelFuncionarios(), ephemeral=True)
+
 # Comandos de Registro e CNH
 @bot.tree.command(name="registrar_jogador", description="Registra um novo jogador no sistema do Detran")
 @app_commands.describe(

--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -21,18 +21,18 @@ CANAL_REGISTRO = 1403794454413967526
 # Configurações de permissões por cargo
 CARGOS_PERMISSOES = {
     "Diretor": [
-        "registrar", "cnh_emitir", "cnh_renovar", "cnh_suspender", "cnh_cassar",
+        "painel", "registrar", "cnh_emitir", "cnh_renovar", "cnh_suspender", "cnh_cassar",
         "membro_adicionar", "membro_remover", "veiculo_registrar", "veiculo_transferir",
         "veiculo_apreender", "veiculo_liberar", "multar", "multa_pagar", "multa_recorrer",
         "curso_inscrever", "curso_aprovar", "curso_reprovar", "blitz_iniciar", "blitz_finalizar",
         "relatorios"
     ],
     "Instrutor": [
-        "registrar", "cnh_emitir", "cnh_renovar", "veiculo_registrar", "veiculo_transferir",
+        "painel", "registrar", "cnh_emitir", "cnh_renovar", "veiculo_registrar", "veiculo_transferir",
         "curso_inscrever", "curso_aprovar", "curso_reprovar"
     ],
     "Agente": [
-        "veiculo_apreender", "veiculo_liberar", "multar", "blitz_iniciar", "blitz_finalizar"
+        "painel", "veiculo_apreender", "veiculo_liberar", "multar", "blitz_iniciar", "blitz_finalizar"
     ]
 }
 


### PR DESCRIPTION
## Resumo
- adiciona comando `/painel` para exibir o painel de controle com atalhos
- inclui `painel` nas permissões dos cargos

## Testes
- `python -m py_compile detran_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a776ca2288832386b69c100b0a0297

## Resumo por Sourcery

Adiciona o comando slash `/painel` para exibir um embed de painel de controle com botões de acesso rápido e concede sua permissão a funções relevantes.

Novas Funcionalidades:
- Introduz o comando slash `/painel` para mostrar um painel de controle com botões de atalho.
- Adiciona a permissão `painel` às configurações das funções Diretor, Instrutor e Agente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add `/painel` slash command for displaying a control panel embed with quick-access buttons and grant its permission to relevant roles

New Features:
- Introduce `/painel` slash command to show a control panel with shortcut buttons
- Add `painel` permission to Director, Instrutor, and Agente role configurations

</details>