### PR TITLE
Fix Discord bot command loading

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from discord import app_commands
 import os
 from datetime import datetime
+import sqlite3
 from database import DetranDatabase
 from config import *
 
@@ -422,16 +423,6 @@ async def veiculo_liberar(interaction: discord.Interaction, placa: str):
     
     await interaction.response.send_message(embed=embed)
 
-# Comando para executar o bot
-if __name__ == "__main__":
-    # Verificar se o token foi definido
-    if DISCORD_TOKEN == "SEU_TOKEN_AQUI":
-        print("❌ ERRO: Token do Discord não configurado!")
-        print("Edite o arquivo config.py e defina seu token do Discord.")
-    else:
-        bot.run(DISCORD_TOKEN)
-
-
 # Comandos de Multas e Infrações
 @bot.tree.command(name="multar", description="Aplica uma multa a um jogador")
 @app_commands.describe(
@@ -808,7 +799,6 @@ async def relatorio_multas_agente(interaction: discord.Interaction, agente: disc
         await interaction.response.send_message(embed=embed, ephemeral=True)
         return
     
-    import sqlite3
     with sqlite3.connect(db.db_path) as conn:
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
@@ -855,7 +845,6 @@ async def relatorio_cnhs_suspensas(interaction: discord.Interaction):
         await interaction.response.send_message(embed=embed, ephemeral=True)
         return
     
-    import sqlite3
     with sqlite3.connect(db.db_path) as conn:
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
@@ -892,6 +881,12 @@ async def relatorio_cnhs_suspensas(interaction: discord.Interaction):
     embed.set_footer(text=f"Relatório gerado em {datetime.now().strftime('%d/%m/%Y %H:%M')}")
     await interaction.response.send_message(embed=embed)
 
-# Importar sqlite3 no início do arquivo
-import sqlite3
+# Comando para executar o bot
+if __name__ == "__main__":
+    # Verificar se o token foi definido
+    if DISCORD_TOKEN == "SEU_TOKEN_AQUI":
+        print("❌ ERRO: Token do Discord não configurado!")
+        print("Edite o arquivo config.py e defina seu token do Discord.")
+    else:
+        bot.run(DISCORD_TOKEN)
 


### PR DESCRIPTION
## Summary
- import sqlite3 at startup
- run bot only after all commands are registered

## Testing
- `python -m py_compile detran_bot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a75fea61f88323be7412bb9af1df5a

## Resumo por Sourcery

Corrige o carregamento de comandos importando sqlite3 no topo e iniciando o bot somente depois que todos os comandos estiverem totalmente registrados sob a guarda principal.

Melhorias:
- Importa sqlite3 uma vez na inicialização do módulo e remove importações duplicadas dentro de funções.
- Adia a execução de bot.run sob a guarda principal até que todos os comandos estejam registrados.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix command loading by importing sqlite3 at the top and starting the bot only after commands are fully registered under the main guard

Enhancements:
- Import sqlite3 once at module startup and remove duplicate in-function imports
- Defer bot.run under the main guard until after all commands are registered

</details>