### PR TITLE
fix: set custom IDs for persistent view buttons

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -63,14 +63,22 @@ class PainelFuncionarios(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
 
-    @discord.ui.button(label="Registrar Jogador", style=discord.ButtonStyle.primary)
+    @discord.ui.button(
+        label="Registrar Jogador",
+        style=discord.ButtonStyle.primary,
+        custom_id="painel_registrar_jogador"
+    )
     async def registrar_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message(
             "Use o comando /registrar_jogador para registrar um novo jogador.",
             ephemeral=True
         )
 
-    @discord.ui.button(label="Emitir CNH", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(
+        label="Emitir CNH",
+        style=discord.ButtonStyle.secondary,
+        custom_id="painel_emitir_cnh"
+    )
     async def cnh_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message(
             "Use o comando /cnh_emitir para emitir uma CNH.",


### PR DESCRIPTION
## Summary
- assign stable custom IDs to `PainelFuncionarios` buttons so the view can be registered as persistent

## Testing
- `python -m py_compile detran_bot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a79dbed0d08323b4a282ddd5ba4a65

## Resumo por Sourcery

Atribuir IDs personalizados estáveis aos botões do PainelFuncionarios para permitir o registro de visualização persistente no Discord.

Melhorias:
- Adicionar custom_id "painel_registrar_jogador" ao botão Registrar Jogador
- Adicionar custom_id "painel_emitir_cnh" ao botão Emitir CNH

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Assign stable custom IDs to the PainelFuncionarios buttons to enable persistent view registration in Discord.

Enhancements:
- Add custom_id "painel_registrar_jogador" to the Registrar Jogador button
- Add custom_id "painel_emitir_cnh" to the Emitir CNH button

</details>