### PR TITLE
feat: add support ticket system

### DIFF
--- a/detran_bot/README.md
+++ b/detran_bot/README.md
@@ -38,6 +38,10 @@ Bot para Discord que administra e controla o Detran-SP de uma cidade de roleplay
 - Aprovação/reprovação de alunos
 - Controle de status dos cursos
 
+### 🎫 Sistema de Tickets
+- Abertura de tickets de suporte pelos usuários
+- Listagem e encerramento de tickets pela equipe
+
 ### 📊 Relatórios
 - Relatório de multas por agente
 - Lista de CNHs suspensas/revogadas
@@ -141,6 +145,11 @@ O bot usa os seguintes intents:
 - `/curso_inscrever` - Inscreve em curso
 - `/curso_aprovar` - Aprova aluno
 - `/curso_reprovar` - Reprova aluno
+
+### Tickets
+- `/ticket_criar` - Cria um ticket de suporte
+- `/ticket_listar` - Lista tickets por status
+- `/ticket_fechar` - Fecha um ticket de suporte
 
 ### Consultas
 - `/taxas` - Tabela de taxas

--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -25,14 +25,15 @@ CARGOS_PERMISSOES = {
         "membro_adicionar", "membro_remover", "veiculo_registrar", "veiculo_transferir",
         "veiculo_apreender", "veiculo_liberar", "multar", "multa_pagar", "multa_recorrer",
         "curso_inscrever", "curso_aprovar", "curso_reprovar", "blitz_iniciar", "blitz_finalizar",
-        "relatorios"
+        "relatorios", "ticket_listar", "ticket_fechar"
     ],
     "Instrutor": [
         "painel", "registrar", "cnh_emitir", "cnh_renovar", "veiculo_registrar", "veiculo_transferir",
-        "curso_inscrever", "curso_aprovar", "curso_reprovar"
+        "curso_inscrever", "curso_aprovar", "curso_reprovar", "ticket_listar", "ticket_fechar"
     ],
     "Agente": [
-        "painel", "veiculo_apreender", "veiculo_liberar", "multar", "blitz_iniciar", "blitz_finalizar"
+        "painel", "veiculo_apreender", "veiculo_liberar", "multar", "blitz_iniciar", "blitz_finalizar",
+        "ticket_listar", "ticket_fechar"
     ]
 }
 


### PR DESCRIPTION
## Summary
- add database table and methods for support tickets
- include Discord commands to create, list and close tickets
- document and grant permissions for new ticket management commands

## Testing
- `python -m py_compile detran_bot/bot.py detran_bot/database.py detran_bot/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a79fe66984832393fa0365841f0d9f

## Resumo por Sourcery

Adiciona um sistema de tickets de suporte ao bot do Discord, incluindo persistência, comandos de barra, permissões e documentação.

Novas Funcionalidades:
- Introduz o sistema de tickets de suporte com tabela de banco de dados e métodos CRUD para tickets
- Adiciona comandos de barra para criar, listar e fechar tickets de suporte com verificações de permissão

Melhorias:
- Concede novas permissões de gerenciamento de tickets a cargos relevantes na configuração

Documentação:
- Documenta o sistema de tickets e seus comandos no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a support ticket system to the Discord bot, including persistence, slash commands, permissions and documentation.

New Features:
- Introduce support ticket system with database table and CRUD methods for tickets
- Add slash commands to create, list and close support tickets with permission checks

Enhancements:
- Grant new ticket management permissions to relevant roles in config

Documentation:
- Document the ticket system and its commands in the README

</details>