### PR TITLE
feat: allow in-discord bot management

### DIFF
--- a/detran_bot/README.md
+++ b/detran_bot/README.md
@@ -152,6 +152,11 @@ O bot usa os seguintes intents:
 - `/relatorio_multas_agente` - Relatório por agente
 - `/relatorio_cnhs_suspensas` - CNHs suspensas
 
+### Configuração
+- `/config_canal` - Define canais utilizados pelo bot
+- `/config_cargo` - Define cargos utilizados pelo bot
+- `/config_permissao` - Gerencia permissões de cargos para comandos
+
 ## 🔐 Sistema de Permissões
 
 ### Cargos e Permissões

--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 from discord import app_commands
-import os
 from datetime import datetime
 import sqlite3
 from database import DetranDatabase

--- a/detran_bot/database.py
+++ b/detran_bot/database.py
@@ -1,5 +1,4 @@
 import sqlite3
-import os
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
 


### PR DESCRIPTION
## Summary
- allow overriding channel and role ids from inside Discord
- add slash commands to configure channels, roles, and command permissions
- document new configuration commands

## Testing
- `python -m py_compile detran_bot/database.py detran_bot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7a0498dcc8323a3bd1d8114c38d01

## Resumo por Sourcery

Permite a configuração de canais, cargos e permissões de comandos do bot diretamente no Discord, através de novos comandos slash suportados por banco de dados.

Novas Funcionalidades:
- Introduz os comandos slash `/config_canal`, `/config_cargo` e `/config_permissao` para configuração dinâmica do bot
- Permite o gerenciamento de permissões por comando através do comando `/config_permissao`

Melhorias:
- Carrega IDs de canais e cargos do banco de dados na inicialização para sobrescrever configurações estáticas
- Estende as verificações de permissão para incluir permissões de comando atribuídas dinamicamente

Documentação:
- Documenta os novos comandos de configuração no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable in-Discord configuration of bot channels, roles, and command permissions via new slash commands backed by the database.

New Features:
- Introduce slash commands `/config_canal`, `/config_cargo`, and `/config_permissao` for dynamic bot configuration
- Allow per-command permission management through the `/config_permissao` command

Enhancements:
- Load channel and role IDs from the database at startup to override static settings
- Extend permission checks to include dynamically assigned command permissions

Documentation:
- Document the new configuration commands in the README

</details>