### PR TITLE
Use centralized database path

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -4,7 +4,7 @@ from discord import app_commands
 import os
 from datetime import datetime
 import sqlite3
-from database import DetranDatabase
+from database import DetranDatabase, DB_PATH
 from config import *
 
 # Configuração dos intents
@@ -14,7 +14,7 @@ intents.members = True
 
 # Inicialização do bot
 bot = commands.Bot(command_prefix='!', intents=intents)
-db = DetranDatabase()
+db = DetranDatabase(db_path=DB_PATH)
 
 def verificar_permissao(interaction: discord.Interaction, comando: str) -> bool:
     """Verifica se o usuário possui cargos necessários para o comando."""

--- a/detran_bot/database.py
+++ b/detran_bot/database.py
@@ -1,10 +1,12 @@
 import sqlite3
-import os
+import os.path
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
 
+DB_PATH = os.path.join(os.path.dirname(__file__), "detran.db")
+
 class DetranDatabase:
-    def __init__(self, db_path: str = "detran.db"):
+    def __init__(self, db_path: str = DB_PATH):
         self.db_path = db_path
         self.init_database()
     


### PR DESCRIPTION
## Summary
- Centralize database file path in `DB_PATH` constant
- Instantiate `DetranDatabase` with explicit `DB_PATH` in bot initialization

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7baa369ac8323a6c2079a17c50083

## Resumo por Sourcery

Centralizar o caminho do arquivo do banco de dados em todo o projeto, introduzindo uma constante DB_PATH e atualizando a inicialização de DetranDatabase de acordo.

Melhorias:
- Definir uma constante global DB_PATH para a localização do arquivo do banco de dados
- Atualizar DetranDatabase para usar DB_PATH como seu caminho padrão
- Passar a constante DB_PATH explicitamente ao instanciar DetranDatabase na inicialização do bot
- Substituir a importação direta de `os` por `os.path` para manipulação de caminhos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize the database file path across the project by introducing a DB_PATH constant and updating DetranDatabase initialization accordingly.

Enhancements:
- Define a global DB_PATH constant for the database file location
- Update DetranDatabase to use DB_PATH as its default path
- Pass the DB_PATH constant explicitly when instantiating DetranDatabase in bot initialization
- Replace direct os import with os.path for path handling

</details>