### PR TITLE
Add panels, suggestions and notices

### DIFF
--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -17,6 +17,19 @@ ROLE_REGISTRADO = 1408159947015065630
 CANAL_PAINEL_FUNCIONARIOS = 1408158616783163616
 # Canal onde novos membros devem se registrar
 CANAL_REGISTRO = 1403794454413967526
+"""
+Novos canais e categorias utilizados pelo bot.
+"""
+# Canal para painel de tickets
+CANAL_TICKETS = 1408251485824880742
+# Categoria onde os tickets serão criados
+CATEGORIA_TICKETS = 1408251716398223472
+# Canal para painel de cursos
+CANAL_CURSOS = 1405644809741406380
+# Canal para painel de sugestões
+CANAL_SUGESTOES = 1405306477333446736
+# Canal onde avisos serão publicados
+CANAL_AVISOS = 1405643532126916809
 
 # Configurações de permissões por cargo
 CARGOS_PERMISSOES = {
@@ -25,7 +38,7 @@ CARGOS_PERMISSOES = {
         "membro_adicionar", "membro_remover", "veiculo_registrar", "veiculo_transferir",
         "veiculo_apreender", "veiculo_liberar", "multar", "multa_pagar", "multa_recorrer",
         "curso_inscrever", "curso_aprovar", "curso_reprovar", "blitz_iniciar", "blitz_finalizar",
-        "relatorios", "ticket_listar", "ticket_fechar"
+        "relatorios", "ticket_listar", "ticket_fechar", "aviso"
     ],
     "Instrutor": [
         "painel", "registrar", "cnh_emitir", "cnh_renovar", "veiculo_registrar", "veiculo_transferir",

--- a/detran_bot/database.py
+++ b/detran_bot/database.py
@@ -130,6 +130,16 @@ class DetranDatabase:
                     data_criacao TEXT NOT NULL
                 )
             ''')
+
+            # Tabela de sugestões
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS sugestoes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    autor_id TEXT NOT NULL,
+                    sugestao TEXT NOT NULL,
+                    data_criacao TEXT NOT NULL
+                )
+            ''')
             
             conn.commit()
             
@@ -269,7 +279,7 @@ class DetranDatabase:
         """Emite uma nova CNH para um jogador"""
         numero_registro = f"CNH{rg_game}{categoria}{datetime.now().strftime('%Y%m%d')}"
         data_emissao = datetime.now().strftime('%Y-%m-%d')
-        data_validade = (datetime.now() + timedelta(days=1825)).strftime('%Y-%m-%d')  # 5 anos
+        data_validade = (datetime.now() + timedelta(days=15)).strftime('%Y-%m-%d')  # 15 dias
         
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
@@ -505,4 +515,17 @@ class DetranDatabase:
             ''', (ticket_id,))
             conn.commit()
             return cursor.rowcount > 0
+
+    # Métodos para Sugestões
+    def criar_sugestao(self, autor_id: str, sugestao: str) -> int:
+        """Registra uma nova sugestão"""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            data_criacao = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            cursor.execute('''
+                INSERT INTO sugestoes (autor_id, sugestao, data_criacao)
+                VALUES (?, ?, ?)
+            ''', (autor_id, sugestao, data_criacao))
+            conn.commit()
+            return cursor.lastrowid
 


### PR DESCRIPTION
## Summary
- add channel and category constants
- add interactive panels for registration, tickets, courses and suggestions
- implement suggestion storage and notice command
- shorten CNH validity to 15 days and auto-register players on emission

## Testing
- `python -m py_compile detran_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7c0e752748323a7dd73635050f130