### PR TITLE
refactor: centralize embed creation and permission checks

### DIFF
--- a/detran_bot/utils.py
+++ b/detran_bot/utils.py
@@ -1,0 +1,43 @@
+"""Funções utilitárias para o bot do Detran."""
+
+import discord
+
+from config import (
+    CORES,
+    ROLE_GERENCIA,
+    ROLE_FUNCIONARIOS,
+    PERMISSOES_FUNCIONARIOS,
+)
+
+
+EMBED_ICONS = {
+    "erro": "❌",
+    "sucesso": "✅",
+    "info": "ℹ️",
+    "aviso": "⚠️",
+}
+
+
+def criar_embed(tipo: str, titulo: str, descricao: str) -> discord.Embed:
+    """Cria um embed padronizado."""
+    prefixo = EMBED_ICONS.get(tipo, "")
+    embed = discord.Embed(
+        title=f"{prefixo} {titulo}" if prefixo else titulo,
+        description=descricao,
+        color=CORES.get(tipo, CORES["info"]),
+    )
+    return embed
+
+
+def verificar_permissao(interaction: discord.Interaction, comando: str) -> bool:
+    """Verifica se o usuário possui permissão para executar o comando."""
+    role_ids = [role.id for role in interaction.user.roles]
+
+    if ROLE_GERENCIA in role_ids:
+        return True
+
+    if ROLE_FUNCIONARIOS in role_ids:
+        return comando in PERMISSOES_FUNCIONARIOS
+
+    return False
+


### PR DESCRIPTION
## Summary
- centralize embed creation and permission validation in new `utils` module
- update bot to use unified helpers for cleaner logic

## Testing
- `python -m py_compile detran_bot/*.py`
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c37bb3cc832380bd87f5d24508e5

## Resumo por Sourcery

Centraliza a criação de embeds e a validação de permissões em um novo módulo `utils` e atualiza o bot para usar funções auxiliares unificadas para uma lógica de comando mais limpa e *DRY* (Don't Repeat Yourself).

Melhorias:
- Introduz `utils.criar_embed` para padronizar a geração de embeds com ícones e cores
- Introduz `utils.verificar_permissao` para centralizar as verificações de permissão com base nas funções dos usuários
- Remove funções duplicadas de embed e permissão de `bot.py` e as substitui por chamadas para os novos auxiliares de `utils`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize embed creation and permission validation in a new utils module and update the bot to use unified helper functions for cleaner and DRY command logic.

Enhancements:
- Introduce utils.criar_embed to standardize embed generation with icons and colors
- Introduce utils.verificar_permissao to centralize permission checks based on user roles
- Remove duplicated embed and permission functions from bot.py and replace them with calls to the new utils helpers

</details>