### PR TITLE
Add logging system to inform Discord channel

### DIFF
--- a/detran_bot/bot.py
+++ b/detran_bot/bot.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import sqlite3
 from database import DetranDatabase, DB_PATH
 from config import *
-from utils import verificar_permissao, criar_embed
+from utils import verificar_permissao, criar_embed, enviar_log
 
 # Configuração dos intents
 intents = discord.Intents.default()
@@ -204,6 +204,8 @@ async def on_ready():
     except Exception as e:
         print(f'Erro ao sincronizar comandos: {e}')
 
+    await enviar_log(bot, "Bot iniciado e online.")
+
     bot.add_view(PainelFuncionarios())
     bot.add_view(PainelRegistro())
     bot.add_view(PainelTickets())
@@ -256,6 +258,23 @@ async def on_ready():
             color=CORES["info"]
         )
         await canal_sugestoes.send(embed=embed, view=PainelSugestao())
+
+
+@bot.event
+async def on_app_command_completion(interaction: discord.Interaction, command: app_commands.Command):
+    await enviar_log(bot, f"Comando /{command.name} executado por {interaction.user} ({interaction.user.id})")
+
+
+@bot.tree.error
+async def on_app_command_error(interaction: discord.Interaction, error: app_commands.AppCommandError):
+    await enviar_log(bot, (
+        f"Erro ao executar /{interaction.command.name} por {interaction.user} ({interaction.user.id}): {error}"
+    ))
+    embed = criar_embed("erro", "Erro", "Ocorreu um erro ao executar o comando.")
+    try:
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+    except Exception:
+        pass
 
 
 @bot.event

--- a/detran_bot/config.py
+++ b/detran_bot/config.py
@@ -17,6 +17,8 @@ ROLE_REGISTRADO = 1408159947015065630
 CANAL_PAINEL_FUNCIONARIOS = 1408158616783163616
 # Canal onde novos membros devem se registrar
 CANAL_REGISTRO = 1403794454413967526
+# Canal onde os logs do sistema serão enviados
+CANAL_LOGS = 1406433637087449128
 """
 Novos canais e categorias utilizados pelo bot.
 """

--- a/detran_bot/utils.py
+++ b/detran_bot/utils.py
@@ -1,12 +1,14 @@
 """Funções utilitárias para o bot do Detran."""
 
 import discord
+from discord.ext import commands
 
 from config import (
     CORES,
     ROLE_GERENCIA,
     ROLE_FUNCIONARIOS,
     PERMISSOES_FUNCIONARIOS,
+    CANAL_LOGS,
 )
 
 
@@ -40,4 +42,11 @@ def verificar_permissao(interaction: discord.Interaction, comando: str) -> bool:
         return comando in PERMISSOES_FUNCIONARIOS
 
     return False
+
+
+async def enviar_log(bot: commands.Bot, mensagem: str) -> None:
+    """Envia uma mensagem de log para o canal configurado."""
+    canal = bot.get_channel(CANAL_LOGS)
+    if canal:
+        await canal.send(mensagem)
 


### PR DESCRIPTION
## Summary
- add constant for log channel and helper to send log messages
- log bot startup, command usage, and errors to the configured channel

## Testing
- `python -m py_compile detran_bot/config.py detran_bot/utils.py detran_bot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7c9641a348323864686beda011f3f

## Resumo por Sourcery

Introduz um sistema de log para enviar eventos de inicialização do bot, execução de comandos e erros para um canal do Discord configurado.

Novas Funcionalidades:
- Registra o evento de inicialização do bot no canal de log designado
- Registra eventos de execução de comandos slash com detalhes do usuário
- Registra erros de comandos slash com detalhes do erro

Melhorias:
- Adiciona a constante de configuração CANAL_LOGS para o canal de log
- Adiciona o helper enviar_log em utils para enviar mensagens de log para o Discord

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a logging system to send bot startup, command execution, and error events to a configured Discord channel.

New Features:
- Log bot startup event to the designated log channel
- Log slash command execution events with user details
- Log slash command errors with error details

Enhancements:
- Add CANAL_LOGS configuration constant for the log channel
- Add enviar_log helper in utils to send log messages to Discord

</details>